### PR TITLE
Update deps for Sailfish OS 2.0.5

### DIFF
--- a/qml/MapPlugin.qml
+++ b/qml/MapPlugin.qml
@@ -36,7 +36,7 @@ Plugin {
     name: "here"
     parameters: [
         PluginParameter { name: "app_id"; value: "N7qPce6rxX5gKujr6ia3"; },
-        PluginParameter { name: "token"; value: "4kEWsRWtJQpNFfQmpnknfA"; },
+        PluginParameter { name: "app_code"; value: "4kEWsRWtJQpNFfQmpnknfA"; },
         PluginParameter { name: "mapping.cache.directory"; value: "/dev/null"; },
         PluginParameter { name: "mapping.host"; value: "127.0.0.1:65536"; }
     ]

--- a/qml/MapPlugin.qml
+++ b/qml/MapPlugin.qml
@@ -33,7 +33,7 @@ import QtLocation 5.0
  */
 
 Plugin {
-    name: "nokia"
+    name: "here"
     parameters: [
         PluginParameter { name: "app_id"; value: "N7qPce6rxX5gKujr6ia3"; },
         PluginParameter { name: "token"; value: "4kEWsRWtJQpNFfQmpnknfA"; },

--- a/rpm/harbour-poor-maps.spec
+++ b/rpm/harbour-poor-maps.spec
@@ -16,7 +16,7 @@ BuildRequires: make
 Requires: libkeepalive
 Requires: libsailfishapp-launcher
 Requires: pyotherside-qml-plugin-python3-qt5 >= 1.2
-Requires: qt5-plugin-geoservices-nokia >= 5.2.1+git9-1.25.1
+Requires: qt5-plugin-geoservices-here >= 5.2.1+git12+upgrade205-1.29.1
 Requires: qt5-qtdeclarative-import-location
 Requires: qt5-qtdeclarative-import-positioning >= 5.2
 Requires: sailfishsilica-qt5

--- a/rpm/harbour-poor-maps.spec
+++ b/rpm/harbour-poor-maps.spec
@@ -16,7 +16,7 @@ BuildRequires: make
 Requires: libkeepalive
 Requires: libsailfishapp-launcher
 Requires: pyotherside-qml-plugin-python3-qt5 >= 1.2
-Requires: qt5-plugin-geoservices-here >= 5.2.1+git12+upgrade205-1.29.1
+Requires: qt5-plugin-geoservices-here
 Requires: qt5-qtdeclarative-import-location
 Requires: qt5-qtdeclarative-import-positioning >= 5.2
 Requires: sailfishsilica-qt5


### PR DESCRIPTION
`qt5-plugin-geoservices-nokia` has been renamed as `qt5-plugin-geoservices-here`.