### PR TITLE
Add OSM Scout Valhalla router

### DIFF
--- a/routers/osmscout.json
+++ b/routers/osmscout.json
@@ -1,8 +1,8 @@
 {
-    "attribution": "Data © OpenStreetMap",
+    "attribution": "Data © OpenStreetMap contributors",
     "_description": "Routing based on OpenStreetMap data",
     "_modes": "car, bicycle, foot",
-    "name": "OSM Scout",
+    "name": "OSM Scout libosmscout",
     "requires": ["harbour-osmscout-server"],
     "_source": "OSM Scout offline server"
 }

--- a/routers/osmscout.json
+++ b/routers/osmscout.json
@@ -1,8 +1,8 @@
 {
     "attribution": "Data © OpenStreetMap",
     "_description": "Routing based on OpenStreetMap data",
-    "name": "OSM Scout",
     "_modes": "car, bicycle, foot",
+    "name": "OSM Scout",
     "requires": ["harbour-osmscout-server"],
     "_source": "OSM Scout offline server"
 }

--- a/routers/osmscout_valhalla.json
+++ b/routers/osmscout_valhalla.json
@@ -1,0 +1,8 @@
+{
+    "attribution": "Data © OpenStreetMap contributors",
+    "_description": "Routing based on OpenStreetMap data",
+    "_modes": "car, bicycle, foot",
+    "name": "OSM Scout Valhalla",
+    "requires": ["harbour-osmscout-server-module-route"],
+    "_source": "OSM Scout offline server"
+}

--- a/routers/osmscout_valhalla.json
+++ b/routers/osmscout_valhalla.json
@@ -3,6 +3,6 @@
     "_description": "Routing based on OpenStreetMap data",
     "_modes": "car, bicycle, foot",
     "name": "OSM Scout Valhalla",
-    "requires": ["harbour-osmscout-server-module-route"],
+    "requires": ["harbour-osmscout-server", "harbour-osmscout-server-module-route"],
     "_source": "OSM Scout offline server"
 }

--- a/routers/osmscout_valhalla.py
+++ b/routers/osmscout_valhalla.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2015 Osmo Salomaa
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Routing using OSM Scout Server's Valhalla router.
+
+https://github.com/rinigus/osmscout-server
+https://github.com/valhalla/valhalla-docs/blob/master/api-reference.md
+"""
+
+import copy
+import json
+import poor
+import urllib.parse
+
+CONF_DEFAULTS = {"type": "auto"}
+
+ICONS = { 0: "flag",
+          1: "depart",
+          2: "depart-right",
+          3: "depart-left",
+          4: "arrive",
+          5: "arrive-right",
+          6: "arrive-left",
+          7: "continue",
+          8: "continue",
+          9: "turn-slight-right",
+         10: "turn-right",
+         11: "turn-sharp-right",
+         12: "uturn",
+         13: "uturn",
+         14: "turn-sharp-left",
+         15: "turn-left",
+         16: "turn-slight-left",
+         17: "continue",
+         18: "off-ramp-slight-right",
+         19: "off-ramp-slight-left",
+         20: "off-ramp-slight-right",
+         21: "off-ramp-slight-left",
+         22: "fork-straight",
+         23: "fork-slight-right",
+         24: "fork-slight-left",
+         25: "merge-slight-left",
+         26: "roundabout",
+         27: "off-ramp-slight-right",
+         28: "flag",
+         29: "flag",
+         30: "flag",
+         31: "flag",
+         32: "flag",
+         33: "flag",
+         34: "flag",
+         35: "flag",
+         36: "flag",
+}
+
+URL = "http://localhost:8553/v2/route?json={input}&language={lang}"
+cache = {}
+
+def prepare_endpoint(point):
+    """Return `point` as a dictionary ready to be passed on to the router."""
+    if isinstance(point, (list, tuple)):
+        return dict(lat=point[1], lon=point[0])
+    geocoder = poor.Geocoder("osmscout")
+    results = geocoder.geocode(point, dict(limit=1))
+    return prepare_endpoint((results[0]["x"], results[0]["y"]))
+
+def route(fm, to, params):
+    """Find route and return its properties as a dictionary."""
+    fm, to = map(prepare_endpoint, (fm, to))
+    type = poor.conf.routers.osmscout_valhalla.type
+    input = dict(locations=[fm, to], costing=type)
+    input = urllib.parse.quote(json.dumps(input))
+    lang = poor.util.get_default_language("en")
+    url = URL.format(**locals())
+    with poor.util.silent(KeyError):
+        return copy.deepcopy(cache[url])
+    result = poor.http.get_json(url)
+    legs = result["trip"]["legs"][0]
+    x, y = poor.util.decode_epl(legs["shape"], precision=6)
+    maneuvers = [dict(
+        x=float(x[maneuver["begin_shape_index"]]),
+        y=float(y[maneuver["begin_shape_index"]]),
+        icon=ICONS.get(maneuver["type"], "flag"),
+        narrative=maneuver["instruction"],
+        duration=float(maneuver["time"]),
+    ) for maneuver in legs["maneuvers"]]
+    route = dict(x=x, y=y, maneuvers=maneuvers)
+    if route and route["x"]:
+        cache[url] = copy.deepcopy(route)
+    return route

--- a/routers/osmscout_valhalla_results.qml
+++ b/routers/osmscout_valhalla_results.qml
@@ -1,0 +1,64 @@
+/* -*- coding: utf-8-unix -*-
+ *
+ * Copyright (C) 2014 Osmo Salomaa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import "../qml"
+
+Page {
+    id: page
+    allowedOrientations: app.defaultAllowedOrientations
+    property bool loading: true
+    BusyModal {
+        id: busy
+        running: page.loading
+    }
+    onStatusChanged: {
+        if (page.status === PageStatus.Activating) {
+            busy.text = qsTranslate("", "Searching");
+        } else if (page.status === PageStatus.Active) {
+            page.findRoute();
+        }
+    }
+    function findRoute() {
+        // Load routing results from the Python backend.
+        var routePage = app.pageStack.previousPage();
+        var args = [routePage.from, routePage.to];
+        py.call("poor.app.router.route", args, function(route) {
+            if (route && route.error && route.message) {
+                busy.error = route.message;
+                page.loading = false;
+            } else if (route && route.x && route.x.length > 0) {
+                app.hideMenu();
+                map.addRoute({
+                    "x": route.x,
+                    "y": route.y,
+                    "mode": "car",
+                    "attribution": qsTranslate("", "Routing courtesy of %1.").arg("OSM Scout Server")
+                });
+                map.hidePoiBubbles();
+                map.fitViewToRoute();
+                map.addManeuvers(route.maneuvers);
+                app.pageStack.navigateBack(PageStackAction.Immediate);
+            } else {
+                busy.error = qsTranslate("", "No results");
+                page.loading = false;
+            }
+        });
+    }
+}

--- a/routers/osmscout_valhalla_results.qml
+++ b/routers/osmscout_valhalla_results.qml
@@ -49,7 +49,11 @@ Page {
                     "x": route.x,
                     "y": route.y,
                     "mode": "car",
-                    "attribution": qsTranslate("", "Routing courtesy of %1.").arg("OSM Scout Server")
+                    // TRANSLATORS: %1 refers to the routing engine, %2 to the service.
+                    "attribution": (qsTranslate("", "Routing by %1, courtesy of %2")
+                                    .arg("Valhalla")
+                                    .arg("OSM Scout Server"))
+
                 });
                 map.hidePoiBubbles();
                 map.fitViewToRoute();

--- a/routers/osmscout_valhalla_settings.qml
+++ b/routers/osmscout_valhalla_settings.qml
@@ -1,0 +1,41 @@
+/* -*- coding: utf-8-unix -*-
+ *
+ * Copyright (C) 2014 Osmo Salomaa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+Column {
+    ComboBox {
+        id: typeComboBox
+        label: qsTranslate("", "Type")
+        menu: ContextMenu {
+            MenuItem { text: qsTranslate("", "Car") }
+            MenuItem { text: qsTranslate("", "Bicycle") }
+            MenuItem { text: qsTranslate("", "Foot") }
+        }
+        property var keys: ["auto", "bicycle", "pedestrian"]
+        Component.onCompleted: {
+            var key = app.conf.get("routers.osmscout_valhalla.type");
+            typeComboBox.currentIndex = typeComboBox.keys.indexOf(key);
+        }
+        onCurrentIndexChanged: {
+            var option = "routers.osmscout_valhalla.type";
+            app.conf.set(option, typeComboBox.keys[typeComboBox.currentIndex]);
+        }
+    }
+}


### PR DESCRIPTION
@rinigus Can you check if this is OK?

* The router is added under the name "OSM Scout Valhalla". If I understood correctly from earlier discussions, we'd support both libosmscout and Valhalla for now and maybe drop libosmscout later?

* I marked "harbour-osmscout-server-module-route" as a requirement, so the Valhalla router is only visible to those who have the module installed.

* The "osmscout" geocoder is used to get coordinates.