### PR TITLE
add car style osmscout basemaps

### DIFF
--- a/tilesources/osmscout_car_day_@1x.json
+++ b/tilesources/osmscout_car_day_@1x.json
@@ -1,0 +1,10 @@
+{
+    "attribution": "Data © OpenStreetMap contributors",
+    "extension": ".png",
+    "format": "slippy",
+    "_name": "OSM Scout car day @1x",
+    "requires": ["harbour-osmscout-server"],
+    "scale": 2,
+    "_source": "OSM Scout offline server",
+    "url": "http://localhost:8553/v1/tile?style=car&daylight=1&shift=1&scale=2&z={z}&x={x}&y={y}"
+}

--- a/tilesources/osmscout_car_day_@2x.json
+++ b/tilesources/osmscout_car_day_@2x.json
@@ -1,0 +1,10 @@
+{
+    "attribution": "Data © OpenStreetMap contributors",
+    "extension": ".png",
+    "format": "slippy",
+    "_name": "OSM Scout car day @2x",
+    "requires": ["harbour-osmscout-server"],
+    "scale": 4,
+    "_source": "OSM Scout offline server",
+    "url": "http://localhost:8553/v1/tile?style=car&daylight=1&shift=1&scale=4&z={z}&x={x}&y={y}"
+}

--- a/tilesources/osmscout_car_night_@1x.json
+++ b/tilesources/osmscout_car_night_@1x.json
@@ -1,0 +1,10 @@
+{
+    "attribution": "Data © OpenStreetMap contributors",
+    "extension": ".png",
+    "format": "slippy",
+    "_name": "OSM Scout car night @1x",
+    "requires": ["harbour-osmscout-server"],
+    "scale": 2,
+    "_source": "OSM Scout offline server",
+    "url": "http://localhost:8553/v1/tile?style=car&daylight=0&shift=1&scale=2&z={z}&x={x}&y={y}"
+}

--- a/tilesources/osmscout_car_night_@2x.json
+++ b/tilesources/osmscout_car_night_@2x.json
@@ -1,0 +1,10 @@
+{
+    "attribution": "Data © OpenStreetMap contributors",
+    "extension": ".png",
+    "format": "slippy",
+    "_name": "OSM Scout car night @2x",
+    "requires": ["harbour-osmscout-server"],
+    "scale": 4,
+    "_source": "OSM Scout offline server",
+    "url": "http://localhost:8553/v1/tile?style=car&daylight=0&shift=1&scale=4&z={z}&x={x}&y={y}"
+}


### PR DESCRIPTION
This request adds a support for OSM Scout Server car style basemap. This style brings out the features (such as gas stations) that are of interest for motorists. 