### PR TITLE
escape all quotation mark occurrences in string

### DIFF
--- a/qml/Python.qml
+++ b/qml/Python.qml
@@ -50,7 +50,7 @@ Python {
         } else if (obj === null || obj === undefined) {
             return "None";
         } else if (typeof obj === "string") {
-            return "'%1'".arg(obj.replace(new RegExp("'", 'g'), "\\'"));
+            return "'%1'".arg(obj.replace(/'/g, "\\'"));
         } else if (typeof obj === "number") {
             return obj.toString();
         } else if (typeof obj === "boolean") {

--- a/qml/Python.qml
+++ b/qml/Python.qml
@@ -50,7 +50,7 @@ Python {
         } else if (obj === null || obj === undefined) {
             return "None";
         } else if (typeof obj === "string") {
-            return "'%1'".arg(obj.replace(/'/, "\\'"));
+            return "'%1'".arg(obj.replace(new RegExp("'", 'g'), "\\'"));
         } else if (typeof obj === "number") {
             return obj.toString();
         } else if (typeof obj === "boolean") {


### PR DESCRIPTION
I stumbled upon the case where there were two ' in a sentence. As a result, the python call_sync failed. This PR ensures that all ' marks are replaced in a string, not only the first one as before