### PR TITLE
Allow disabling double tap behaviour

### DIFF
--- a/poor/config.py
+++ b/poor/config.py
@@ -34,6 +34,7 @@ DEFAULTS = {
     "basemap_filter": "",
     "cache_max_age": 30, # days
     "center": [0.0, 0.0],
+    "double_tap_center": True,
     "geocoder": "mapzen",
     "guide": "foursquare",
     # "always", "navigating" or "never".

--- a/qml/MapMouseArea.qml
+++ b/qml/MapMouseArea.qml
@@ -22,7 +22,7 @@ import QtPositioning 5.3
 MouseArea {
     anchors.fill: parent
     onClicked: map.hidePoiBubbles();
-    onDoubleClicked: map.centerOnPosition();
+    onDoubleClicked: app.conf.get("double_tap_center") && map.centerOnPosition();
     onPressAndHold: {
         var coord = map.toCoordinate(Qt.point(mouse.x, mouse.y));
         map.addPois([{

--- a/qml/PreferencesPage.qml
+++ b/qml/PreferencesPage.qml
@@ -50,6 +50,19 @@ Page {
                 }
             }
 
+
+            TextSwitch {
+                id: doubleTapItem
+                checked: app.conf.get("double_tap_center")
+                text: app.tr("Double tap to center on position")
+                onCheckedChanged: {
+                    var value = doubleTapItem.checked
+                    if (value === app.conf.get("double_tap_center")) return;
+                    app.conf.set("double_tap_center", value);
+                }
+            }
+
+
             ComboBox {
                 id: unitsComboBox
                 label: app.tr("Units")


### PR DESCRIPTION
Add TextSwitch in Preferences to allow disabling centering
at double tap.
This centering can be quit annoying especially when looking up
a location far away.